### PR TITLE
Deprecated class »EmailValidator« fixed

### DIFF
--- a/src/info/bliki/wiki/filter/WikipediaParser.java
+++ b/src/info/bliki/wiki/filter/WikipediaParser.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.validator.EmailValidator;
+import org.apache.commons.validator.routines.EmailValidator;
 
 /**
  * A Wikipedia syntax parser for the second pass in the parsing of a Wikipedia


### PR DESCRIPTION
The new suggestion is to use the package »routines«, see http://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/EmailValidator.html